### PR TITLE
chore: bump ItemsPlanningBase to 10.0.35 (apply RepeatOrdinalWeek migration)

### DIFF
--- a/eFormAPI/Plugins/ItemsPlanning.Pn/ItemsPlanning.Pn/ItemsPlanning.Pn.csproj
+++ b/eFormAPI/Plugins/ItemsPlanning.Pn/ItemsPlanning.Pn/ItemsPlanning.Pn.csproj
@@ -28,7 +28,7 @@
       <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
       <PackageReference Include="Microting.eForm" Version="10.0.35" />
       <PackageReference Include="Microting.eFormApi.BasePn" Version="10.0.29" />
-      <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.34" />
+      <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.35" />
       <PackageReference Include="Sentry" Version="6.6.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Bumps `Microting.ItemsPlanningBase` 10.0.34→10.0.35 in the items-planning host plugin, which owns the `Plannings` table migrations. This makes the host apply `AddRepeatOrdinalWeekToPlanning` so the new `Planning.RepeatOrdinalWeek` column exists before any consumer (backend-config plugin/services) queries it.

Required deploy-order fix: without it, an environment running the backend-config plugin at base 10.0.35 hits `Unknown column 'p.RepeatOrdinalWeek'` on every Planning query (observed in backend-config PR #1012's e2e). eForm/BasePn already at the required 10.0.35/10.0.29 floors — single-line bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)